### PR TITLE
fix: WeakReference stacks

### DIFF
--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/TailLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/TailLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.item.armor.TailArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
 import com.hakimen.kawaiidishes.utils.AnimalType;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.hakimen.kawaiidishes.utils.TailUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -16,8 +15,10 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
+
 public class TailLayer extends GeoArmorLayer<TailArmorItem> {
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
     AnimalType tail;
 
@@ -26,15 +27,19 @@ public class TailLayer extends GeoArmorLayer<TailArmorItem> {
     }
 
     public void updateStack(ItemStack stack) {
-        this.stackData = stack;
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
 
     @Override
     public ResourceLocation getTexture() {
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"),
-                TailUtils.getTailOverlayTextures().get(((TailArmorItem)stackData.getItem()).getTailType())
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
+                TailUtils.getTailOverlayTextures().get(((TailArmorItem) getStack().getItem()).getTailType())
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
     }
 
     @Override
@@ -50,6 +55,6 @@ public class TailLayer extends GeoArmorLayer<TailArmorItem> {
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getOverlay());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getOverlay());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/ears_layers/EarSkinLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/ears_layers/EarSkinLayer.java
@@ -14,19 +14,26 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
-public class EarSkinLayer extends GeoArmorLayer<EarsArmorItem> {
-    ItemStack stackData;
+import java.lang.ref.WeakReference;
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+public class EarSkinLayer extends GeoArmorLayer<EarsArmorItem> {
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public EarSkinLayer(GeoRenderer<EarsArmorItem> entityRendererIn) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"));
     }
 
     @Override
     public ResourceLocation getTexture() {
-        return EarUtils.getEarSkinTexture().get(((EarsArmorItem)stackData.getItem()).getEarsType());
+        return EarUtils.getEarSkinTexture().get(((EarsArmorItem) getStack().getItem()).getEarsType());
     }
 
     @Override

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/ears_layers/EarsLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/ears_layers/EarsLayer.java
@@ -4,24 +4,30 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.EarsArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.hakimen.kawaiidishes.utils.EarUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
+
 public class EarsLayer extends GeoArmorLayer<EarsArmorItem> {
-    ItemStack stackData;
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public EarsLayer(GeoRenderer<EarsArmorItem> entityRendererIn) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"));
     }
@@ -30,8 +36,8 @@ public class EarsLayer extends GeoArmorLayer<EarsArmorItem> {
     public ResourceLocation getTexture() {
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"),
-                EarUtils.getEarOverlayTextures().get(((EarsArmorItem)stackData.getItem()).getEarsType())
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
+                EarUtils.getEarOverlayTextures().get(((EarsArmorItem) getStack().getItem()).getEarsType())
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
     }
 
     @Override
@@ -46,6 +52,6 @@ public class EarsLayer extends GeoArmorLayer<EarsArmorItem> {
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getOverlay());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getOverlay());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_band_layers/HeadBandRibbonLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_band_layers/HeadBandRibbonLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.HeadBandArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -15,11 +14,17 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
-public class HeadBandRibbonLayer extends GeoArmorLayer<HeadBandArmorItem> {
-    ItemStack stackData;
+import java.lang.ref.WeakReference;
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+public class HeadBandRibbonLayer extends GeoArmorLayer<HeadBandArmorItem> {
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
     public HeadBandRibbonLayer(GeoRenderer<HeadBandArmorItem> entityRendererIn) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/head_band/head_band_overlay.png"));
@@ -30,7 +35,7 @@ public class HeadBandRibbonLayer extends GeoArmorLayer<HeadBandArmorItem> {
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/none.png"),
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/head_band/head_band_overlay.png")
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
     }
 
     @Override
@@ -45,6 +50,6 @@ public class HeadBandRibbonLayer extends GeoArmorLayer<HeadBandArmorItem> {
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getOverlay());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getOverlay());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_bands_with_ears_layers/EarsBaseLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_bands_with_ears_layers/EarsBaseLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.HeadBandWithEarsArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.hakimen.kawaiidishes.utils.HeadBandsWithEarsUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -16,19 +15,26 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
-public class EarsBaseLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
-    ItemStack stackData;
+import java.lang.ref.WeakReference;
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+public class EarsBaseLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public EarsBaseLayer(GeoRenderer<HeadBandWithEarsArmorItem> entityRendererIn) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"));
     }
 
     @Override
     public ResourceLocation getTexture() {
-        return HeadBandsWithEarsUtils.getEaredHeadBandsEarsBase().get(((HeadBandWithEarsArmorItem)stackData.getItem()).getEarsType());
+        return HeadBandsWithEarsUtils.getEaredHeadBandsEarsBase().get(((HeadBandWithEarsArmorItem) getStack().getItem()).getEarsType());
     }
 
     @Override
@@ -44,6 +50,6 @@ public class EarsBaseLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getSecondaryBase());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getSecondaryBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_bands_with_ears_layers/EarsOverlayLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_bands_with_ears_layers/EarsOverlayLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.HeadBandWithEarsArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.hakimen.kawaiidishes.utils.HeadBandsWithEarsUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -16,11 +15,17 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
-public class EarsOverlayLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
-    ItemStack stackData;
+import java.lang.ref.WeakReference;
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+public class EarsOverlayLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
     public EarsOverlayLayer(GeoRenderer<HeadBandWithEarsArmorItem> entityRendererIn) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"));
@@ -28,7 +33,7 @@ public class EarsOverlayLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
 
     @Override
     public ResourceLocation getTexture() {
-        return HeadBandsWithEarsUtils.getEaredHeadBandsEarsOverlay().get(((HeadBandWithEarsArmorItem)stackData.getItem()).getEarsType());
+        return HeadBandsWithEarsUtils.getEaredHeadBandsEarsOverlay().get(((HeadBandWithEarsArmorItem) getStack().getItem()).getEarsType());
     }
 
     @Override
@@ -44,6 +49,6 @@ public class EarsOverlayLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getSecondaryOverlay());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getSecondaryOverlay());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_bands_with_ears_layers/EarsSkinLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_bands_with_ears_layers/EarsSkinLayer.java
@@ -3,7 +3,6 @@ package com.hakimen.kawaiidishes.client.entity.models.layers.head_bands_with_ear
 import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.HeadBandWithEarsArmorItem;
-import com.hakimen.kawaiidishes.registry.DataComponentRegister;
 import com.hakimen.kawaiidishes.utils.HeadBandsWithEarsUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -15,20 +14,27 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
+
 public class EarsSkinLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public EarsSkinLayer(GeoRenderer<HeadBandWithEarsArmorItem> entityRendererIn) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"));
     }
 
     @Override
     public ResourceLocation getTexture() {
-        return HeadBandsWithEarsUtils.getEaredHeadBandsEarsSkin().get(((HeadBandWithEarsArmorItem)stackData.getItem()).getEarsType());
+        return HeadBandsWithEarsUtils.getEaredHeadBandsEarsSkin().get(((HeadBandWithEarsArmorItem) getStack().getItem()).getEarsType());
     }
 
     @Override

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_bands_with_ears_layers/HeadBandOverlayLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/head_bands_with_ears_layers/HeadBandOverlayLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.HeadBandWithEarsArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -15,11 +14,17 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
-public class HeadBandOverlayLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
-    ItemStack stackData;
+import java.lang.ref.WeakReference;
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+public class HeadBandOverlayLayer extends GeoArmorLayer<HeadBandWithEarsArmorItem> {
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
     public HeadBandOverlayLayer(GeoRenderer<HeadBandWithEarsArmorItem> entityRendererIn, ItemStack stack) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/head_bands_with_ears/head_bands/%s/head_band_overlay.png".formatted(((HeadBandWithEarsArmorItem)stack.getItem()).getEarsType().toString().toLowerCase())));
@@ -27,7 +32,7 @@ public class HeadBandOverlayLayer extends GeoArmorLayer<HeadBandWithEarsArmorIte
 
     @Override
     public ResourceLocation getTexture() {
-        return ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/head_bands_with_ears/head_bands/%s/head_band_overlay.png".formatted(((HeadBandWithEarsArmorItem)stackData.getItem()).getEarsType().toString().toLowerCase()));
+        return ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/head_bands_with_ears/head_bands/%s/head_band_overlay.png".formatted(((HeadBandWithEarsArmorItem) getStack().getItem()).getEarsType().toString().toLowerCase()));
     }
 
     @Override
@@ -44,5 +49,6 @@ public class HeadBandOverlayLayer extends GeoArmorLayer<HeadBandWithEarsArmorIte
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getOverlay());}
+                getStack().get(DataComponentRegister.DYEABLE.get()).getOverlay());
+    }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/maid_dress_layers/MaidDressOverlayLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/maid_dress_layers/MaidDressOverlayLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.MaidDressArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -15,13 +14,20 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
+
 public class MaidDressOverlayLayer extends GeoArmorLayer<MaidDressArmorItem> {
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
     public void updateStack(ItemStack stack){
-        this.stackData = stack;
+        this.stackData = new WeakReference<>(stack);
     }
+
+    private ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public MaidDressOverlayLayer(GeoRenderer<MaidDressArmorItem> entityRendererIn) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/maid_dress/maid_dress.png"));
     }
@@ -31,7 +37,7 @@ public class MaidDressOverlayLayer extends GeoArmorLayer<MaidDressArmorItem> {
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/none.png"),
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/maid_dress/maid_dress_overlay.png")
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
     }
 
     @Override
@@ -46,6 +52,6 @@ public class MaidDressOverlayLayer extends GeoArmorLayer<MaidDressArmorItem> {
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getOverlay());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getOverlay());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/maid_dresses_with_tail_layers/MaidDressOverlayLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/maid_dresses_with_tail_layers/MaidDressOverlayLayer.java
@@ -1,11 +1,9 @@
 package com.hakimen.kawaiidishes.client.entity.models.layers.maid_dresses_with_tail_layers;
 
 import com.hakimen.kawaiidishes.KawaiiDishes;
-import com.hakimen.kawaiidishes.client.entity.models.MaidDressesWithTailArmorModel;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.MaidDressesWithTailArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -16,12 +14,19 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
-public class MaidDressOverlayLayer extends GeoArmorLayer<MaidDressesWithTailArmorItem> {
-    ItemStack stackData;
+import java.lang.ref.WeakReference;
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+public class MaidDressOverlayLayer extends GeoArmorLayer<MaidDressesWithTailArmorItem> {
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public MaidDressOverlayLayer(GeoRenderer<MaidDressesWithTailArmorItem> entityRendererIn) {
         super(entityRendererIn, ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/none.png"));
     }
@@ -30,8 +35,8 @@ public class MaidDressOverlayLayer extends GeoArmorLayer<MaidDressesWithTailArmo
     public ResourceLocation getTexture() {
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/none.png"),
-                ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/maid_dresses_with_tail/dress/%s/maid_dress_overlay.png".formatted(((MaidDressesWithTailArmorItem)stackData.getItem()).getTailType().name().toLowerCase()))
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
+                ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/maid_dresses_with_tail/dress/%s/maid_dress_overlay.png".formatted(((MaidDressesWithTailArmorItem) getStack().getItem()).getTailType().name().toLowerCase()))
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
     }
 
     @Override
@@ -46,6 +51,6 @@ public class MaidDressOverlayLayer extends GeoArmorLayer<MaidDressesWithTailArmo
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getOverlay());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getOverlay());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/maid_dresses_with_tail_layers/PrimaryTailLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/maid_dresses_with_tail_layers/PrimaryTailLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.MaidDressesWithTailArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
 import com.hakimen.kawaiidishes.utils.AnimalType;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.hakimen.kawaiidishes.utils.MaidDressesWithTailUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -15,8 +14,10 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
+
 public class PrimaryTailLayer extends GeoArmorLayer<MaidDressesWithTailArmorItem> {
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
     AnimalType tail;
 
@@ -26,7 +27,11 @@ public class PrimaryTailLayer extends GeoArmorLayer<MaidDressesWithTailArmorItem
     }
 
     public void updateStack(ItemStack stack) {
-        this.stackData = stack;
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
 
     @Override
@@ -41,6 +46,6 @@ public class PrimaryTailLayer extends GeoArmorLayer<MaidDressesWithTailArmorItem
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getSecondaryBase());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getSecondaryBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/maid_dresses_with_tail_layers/SecondaryTailLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/maid_dresses_with_tail_layers/SecondaryTailLayer.java
@@ -5,7 +5,6 @@ import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.MaidDressesWithTailArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
 import com.hakimen.kawaiidishes.utils.AnimalType;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.hakimen.kawaiidishes.utils.MaidDressesWithTailUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -17,8 +16,10 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
+
 public class SecondaryTailLayer extends GeoArmorLayer<MaidDressesWithTailArmorItem> {
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
     AnimalType tail;
 
@@ -28,7 +29,11 @@ public class SecondaryTailLayer extends GeoArmorLayer<MaidDressesWithTailArmorIt
     }
 
     public void updateStack(ItemStack stack) {
-        this.stackData = stack;
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
 
     @Override
@@ -36,7 +41,7 @@ public class SecondaryTailLayer extends GeoArmorLayer<MaidDressesWithTailArmorIt
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"),
                 MaidDressesWithTailUtils.getTailedDressesTailOverlay().get(tail)
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasSecondaryOverlay() ? 1 : 0];
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasSecondaryOverlay() ? 1 : 0];
     }
 
     @Override
@@ -52,5 +57,6 @@ public class SecondaryTailLayer extends GeoArmorLayer<MaidDressesWithTailArmorIt
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getSecondaryOverlay()) ;}
+                getStack().get(DataComponentRegister.DYEABLE.get()).getSecondaryOverlay());
+    }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/shoe_layers/ShoesOverlayLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/shoe_layers/ShoesOverlayLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.ShoesArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -15,11 +14,18 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
+
 public class ShoesOverlayLayer extends GeoArmorLayer<ShoesArmorItem> {
 
-    ItemStack stackData;
-    public void updateStack(ItemStack stack){
-        stackData = stack;
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
 
     public ShoesOverlayLayer(GeoRenderer<ShoesArmorItem> entityRendererIn) {
@@ -31,7 +37,7 @@ public class ShoesOverlayLayer extends GeoArmorLayer<ShoesArmorItem> {
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/none.png"),
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID, "textures/models/armor/shoes/shoes_overlay.png")
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
     }
 
     @Override
@@ -47,6 +53,6 @@ public class ShoesOverlayLayer extends GeoArmorLayer<ShoesArmorItem> {
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getOverlay());
+                getStack().get(DataComponentRegister.DYEABLE.get()).getOverlay());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/thigh_high_layers/ThighHighsDecorationArmorLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/thigh_high_layers/ThighHighsDecorationArmorLayer.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.ThighHighsArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -14,23 +13,27 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
-import org.apache.commons.compress.archivers.zip.ScatterZipOutputStream;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 
 public class ThighHighsDecorationArmorLayer extends GeoArmorLayer<ThighHighsArmorItem> {
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
-    public void updateStack(ItemStack stack){
-        stackData = stack;
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
 
     @Override
     public ResourceLocation getTexture() {
-        return getResourceLocationFromStack(stackData);
+        return getResourceLocationFromStack(getStack());
     }
 
     static List<ResourceLocation> decorations = List.of(
@@ -41,7 +44,7 @@ public class ThighHighsDecorationArmorLayer extends GeoArmorLayer<ThighHighsArmo
     );
     public ThighHighsDecorationArmorLayer(GeoRenderer<ThighHighsArmorItem> entityRendererIn, ItemStack stack) {
         super(entityRendererIn, getResourceLocationFromStack(stack));
-        this.stackData = stack;
+        this.updateStack(stack);
     }
 
     private static ResourceLocation getResourceLocationFromStack(ItemStack stack) {
@@ -70,7 +73,7 @@ public class ThighHighsDecorationArmorLayer extends GeoArmorLayer<ThighHighsArmo
                 partialTick,
                 packedLight,
                 OverlayTexture.NO_OVERLAY,
-                stackData.get(DataComponentRegister.DYEABLE.get()).getOverlay() | 0xff000000);
+                getStack().get(DataComponentRegister.DYEABLE.get()).getOverlay() | 0xff000000);
     }
 
 

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/thigh_high_layers/ThighHighsDecorationDetailArmorLayer.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/models/layers/thigh_high_layers/ThighHighsDecorationDetailArmorLayer.java
@@ -3,7 +3,6 @@ package com.hakimen.kawaiidishes.client.entity.models.layers.thigh_high_layers;
 import com.hakimen.kawaiidishes.KawaiiDishes;
 import com.hakimen.kawaiidishes.client.entity.models.layers.GeoArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.ThighHighsArmorItem;
-import com.hakimen.kawaiidishes.registry.DataComponentRegister;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -15,19 +14,24 @@ import net.minecraft.world.item.ItemStack;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoRenderer;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 
 public class ThighHighsDecorationDetailArmorLayer extends GeoArmorLayer<ThighHighsArmorItem> {
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
-    public void updateStack(ItemStack stack){
-        stackData = stack;
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
 
     @Override
     public ResourceLocation getTexture() {
-        return getResourceLocationFromStack(stackData);
+        return getResourceLocationFromStack(getStack());
     }
 
     static List<ResourceLocation> decorations = List.of(
@@ -35,7 +39,7 @@ public class ThighHighsDecorationDetailArmorLayer extends GeoArmorLayer<ThighHig
     );
     public ThighHighsDecorationDetailArmorLayer(GeoRenderer<ThighHighsArmorItem> entityRendererIn, ItemStack stack) {
         super(entityRendererIn, getResourceLocationFromStack(stack));
-        this.stackData = stack;
+        this.updateStack(stack);
     }
 
     private static ResourceLocation getResourceLocationFromStack(ItemStack stack) {

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/EarsArmorRender.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/EarsArmorRender.java
@@ -4,9 +4,7 @@ import com.hakimen.kawaiidishes.client.entity.models.layers.ears_layers.EarSkinL
 import com.hakimen.kawaiidishes.client.entity.models.layers.ears_layers.EarsLayer;
 import com.hakimen.kawaiidishes.item.armor.EarsArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import net.minecraft.client.model.HumanoidModel;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
@@ -14,11 +12,19 @@ import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.util.Color;
 
+import java.lang.ref.WeakReference;
+
 public class EarsArmorRender extends GeoArmorItemRenderer<EarsArmorItem> {
-    ItemStack stackData;
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public EarsArmorRender(GeoModel<EarsArmorItem> model) {
         super(model);
 
@@ -38,6 +44,6 @@ public class EarsArmorRender extends GeoArmorItemRenderer<EarsArmorItem> {
 
     @Override
     public Color getRenderColor(EarsArmorItem animatable, float partialTick, int packedLight) {
-        return Color.ofOpaque(stackData.get(DataComponentRegister.DYEABLE.get()).getBase());
+        return Color.ofOpaque(getStack().get(DataComponentRegister.DYEABLE.get()).getBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/HeadBandArmorRender.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/HeadBandArmorRender.java
@@ -3,7 +3,6 @@ package com.hakimen.kawaiidishes.client.entity.renderers;
 import com.hakimen.kawaiidishes.client.entity.models.layers.head_band_layers.HeadBandRibbonLayer;
 import com.hakimen.kawaiidishes.item.armor.HeadBandArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -12,21 +11,29 @@ import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.util.Color;
 
+import java.lang.ref.WeakReference;
+
 public class HeadBandArmorRender extends GeoArmorItemRenderer<HeadBandArmorItem> {
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
+
     public HeadBandArmorRender(GeoModel<HeadBandArmorItem> model, ItemStack stack) {
         super(model);
-        this.stackData = stack;
+        this.updateStack(stack);
         addRenderLayer(new HeadBandRibbonLayer(this));
 
         ((HeadBandRibbonLayer)getRenderLayers().get(0)).updateStack(stack);
     }
 
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     @Override
     public void prepForRender(@Nullable Entity entity, ItemStack stack, @Nullable EquipmentSlot slot, @Nullable HumanoidModel<?> baseModel) {
         updateStack(stack);
@@ -38,6 +45,6 @@ public class HeadBandArmorRender extends GeoArmorItemRenderer<HeadBandArmorItem>
 
     @Override
     public Color getRenderColor(HeadBandArmorItem animatable, float partialTick, int packedLight) {
-        return Color.ofOpaque(stackData.get(DataComponentRegister.DYEABLE.get()).getBase());
+        return Color.ofOpaque(getStack().get(DataComponentRegister.DYEABLE.get()).getBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/HeadBandsWithEarsRender.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/HeadBandsWithEarsRender.java
@@ -6,7 +6,6 @@ import com.hakimen.kawaiidishes.client.entity.models.layers.head_bands_with_ears
 import com.hakimen.kawaiidishes.client.entity.models.layers.head_bands_with_ears_layers.HeadBandOverlayLayer;
 import com.hakimen.kawaiidishes.item.armor.HeadBandWithEarsArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
@@ -16,16 +15,22 @@ import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.util.Color;
 
+import java.lang.ref.WeakReference;
+
 public class HeadBandsWithEarsRender extends GeoArmorItemRenderer<HeadBandWithEarsArmorItem>{
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
     public HeadBandsWithEarsRender(GeoModel<HeadBandWithEarsArmorItem> model, ItemStack stack) {
         super(model);
-        this.stackData = stack;
+        updateStack(stack);
 
         addRenderLayer(new HeadBandOverlayLayer(this,stack));
         addRenderLayer(new EarsBaseLayer(this));
@@ -57,6 +62,6 @@ public class HeadBandsWithEarsRender extends GeoArmorItemRenderer<HeadBandWithEa
 
     @Override
     public Color getRenderColor(HeadBandWithEarsArmorItem animatable, float partialTick, int packedLight) {
-        return Color.ofOpaque(stackData.get(DataComponentRegister.DYEABLE.get()).getBase());
+        return Color.ofOpaque(getStack().get(DataComponentRegister.DYEABLE.get()).getBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/MaidDressArmorRender.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/MaidDressArmorRender.java
@@ -19,19 +19,25 @@ import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.util.Color;
 
+import java.lang.ref.WeakReference;
+
 public class MaidDressArmorRender extends GeoArmorItemRenderer<MaidDressArmorItem> {
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
     float chestAngle;
 
     public void updateStack(ItemStack stack) {
-        this.stackData = stack;
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
 
     public MaidDressArmorRender(GeoModel<MaidDressArmorItem> model, ItemStack stack) {
         super(model);
-        this.stackData = stack;
+        this.updateStack(stack);
 
         addRenderLayer(new MaidDressOverlayLayer(this));
         ((MaidDressOverlayLayer) getRenderLayers().get(0)).updateStack(stack);
@@ -41,7 +47,7 @@ public class MaidDressArmorRender extends GeoArmorItemRenderer<MaidDressArmorIte
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/maid_dress/dress.png"),
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/maid_dress/maid_dress.png")
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
     }
 
     @Override
@@ -63,14 +69,7 @@ public class MaidDressArmorRender extends GeoArmorItemRenderer<MaidDressArmorIte
     }
 
     @Override
-    public void postRender(final PoseStack poseStack, final MaidDressArmorItem animatable, final BakedGeoModel model, final MultiBufferSource bufferSource, @Nullable final VertexConsumer buffer, final boolean isReRender, final float partialTick, final int packedLight, final int packedOverlay, final int colour) {
-        super.postRender(poseStack, animatable, model, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, colour);
-
-        this.updateStack(null);
-    }
-
-    @Override
     public Color getRenderColor(MaidDressArmorItem animatable, float partialTick, int packedLight) {
-        return Color.ofOpaque(stackData.get(DataComponentRegister.DYEABLE.get()).getBase());
+        return Color.ofOpaque(getStack().get(DataComponentRegister.DYEABLE.get()).getBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/MaidDressesWithTailArmorRender.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/MaidDressesWithTailArmorRender.java
@@ -21,19 +21,25 @@ import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.util.Color;
 
+import java.lang.ref.WeakReference;
+
 public class MaidDressesWithTailArmorRender extends GeoArmorItemRenderer<MaidDressesWithTailArmorItem> {
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
 
     float chestAngle;
 
     public void updateStack(ItemStack stack) {
-        this.stackData = stack;
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
     }
 
     public MaidDressesWithTailArmorRender(GeoModel<MaidDressesWithTailArmorItem> model, ItemStack stack) {
         super(model);
-        this.stackData = stack;
+        this.updateStack(stack);
 
         addRenderLayer(new MaidDressOverlayLayer(this));
         addRenderLayer(new PrimaryTailLayer(this, ((MaidDressesWithTailArmorItem) stack.getItem()).getTailType()));
@@ -48,7 +54,7 @@ public class MaidDressesWithTailArmorRender extends GeoArmorItemRenderer<MaidDre
         return new ResourceLocation[]{
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/maid_dresses_with_tail/dress/%s/dress.png".formatted(animatable.getTailType().name().toLowerCase())),
                 ResourceLocation.fromNamespaceAndPath(KawaiiDishes.MODID,"textures/models/armor/maid_dresses_with_tail/dress/%s/maid_dress.png".formatted(animatable.getTailType().name().toLowerCase()))
-        }[stackData.get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
+        }[getStack().get(DataComponentRegister.DYEABLE.get()).isHasOverlay() ? 1 : 0];
     }
 
     @Override
@@ -72,14 +78,7 @@ public class MaidDressesWithTailArmorRender extends GeoArmorItemRenderer<MaidDre
     }
 
     @Override
-    public void postRender(final PoseStack poseStack, final MaidDressesWithTailArmorItem animatable, final BakedGeoModel model, final MultiBufferSource bufferSource, @Nullable final VertexConsumer buffer, final boolean isReRender, final float partialTick, final int packedLight, final int packedOverlay, final int colour) {
-        super.postRender(poseStack, animatable, model, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, colour);
-
-        updateStack(null);
-    }
-
-    @Override
     public Color getRenderColor(MaidDressesWithTailArmorItem animatable, float partialTick, int packedLight) {
-        return Color.ofOpaque(stackData.get(DataComponentRegister.DYEABLE.get()).getBase());
+        return Color.ofOpaque(getStack().get(DataComponentRegister.DYEABLE.get()).getBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/ShoesArmorRender.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/ShoesArmorRender.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.client.entity.models.layers.shoe_layers.ShoesOve
 import com.hakimen.kawaiidishes.client.entity.models.layers.shoe_layers.ShoesSolesLayer;
 import com.hakimen.kawaiidishes.item.armor.ShoesArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -13,11 +12,19 @@ import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.util.Color;
 
+import java.lang.ref.WeakReference;
+
 public class ShoesArmorRender extends GeoArmorItemRenderer<ShoesArmorItem> {
-    ItemStack stackData;
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public ShoesArmorRender(GeoModel<ShoesArmorItem> model) {
         super(model);
         addRenderLayer(new ShoesSolesLayer(this));
@@ -35,6 +42,6 @@ public class ShoesArmorRender extends GeoArmorItemRenderer<ShoesArmorItem> {
 
     @Override
     public Color getRenderColor(ShoesArmorItem animatable, float partialTick, int packedLight) {
-        return Color.ofOpaque(stackData.get(DataComponentRegister.DYEABLE.get()).getBase());
+        return Color.ofOpaque(getStack().get(DataComponentRegister.DYEABLE.get()).getBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/TailArmorRender.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/TailArmorRender.java
@@ -3,7 +3,6 @@ package com.hakimen.kawaiidishes.client.entity.renderers;
 import com.hakimen.kawaiidishes.client.entity.models.layers.TailLayer;
 import com.hakimen.kawaiidishes.item.armor.TailArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -12,11 +11,19 @@ import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.util.Color;
 
+import java.lang.ref.WeakReference;
+
 public class TailArmorRender extends GeoArmorItemRenderer<TailArmorItem> {
-    ItemStack stackData;
-    public void updateStack(ItemStack stack){
-        this.stackData = stack;
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
     }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public TailArmorRender(GeoModel<TailArmorItem> model) {
         super(model);
         addRenderLayer(new TailLayer(this));
@@ -33,6 +40,6 @@ public class TailArmorRender extends GeoArmorItemRenderer<TailArmorItem> {
 
     @Override
     public Color getRenderColor(TailArmorItem animatable, float partialTick, int packedLight) {
-        return Color.ofOpaque(stackData.get(DataComponentRegister.DYEABLE.get()).getBase());
+        return Color.ofOpaque(getStack().get(DataComponentRegister.DYEABLE.get()).getBase());
     }
 }

--- a/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/ThighHighsArmorRender.java
+++ b/src/main/java/com/hakimen/kawaiidishes/client/entity/renderers/ThighHighsArmorRender.java
@@ -4,7 +4,6 @@ import com.hakimen.kawaiidishes.client.entity.models.layers.thigh_high_layers.Th
 import com.hakimen.kawaiidishes.client.entity.models.layers.thigh_high_layers.ThighHighsDecorationDetailArmorLayer;
 import com.hakimen.kawaiidishes.item.armor.ThighHighsArmorItem;
 import com.hakimen.kawaiidishes.registry.DataComponentRegister;
-import com.hakimen.kawaiidishes.utils.ColorUtils;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -13,19 +12,30 @@ import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.util.Color;
 
+import java.lang.ref.WeakReference;
+
 public class ThighHighsArmorRender extends GeoArmorItemRenderer<ThighHighsArmorItem> {
 
-    ItemStack stackData;
+    private WeakReference<ItemStack> stackData;
+
+    public void updateStack(ItemStack stack) {
+        this.stackData = new WeakReference<>(stack);
+    }
+
+    public ItemStack getStack() {
+        return this.stackData.get();
+    }
+
     public ThighHighsArmorRender(GeoModel<ThighHighsArmorItem> model, ItemStack stack) {
         super(model);
-        this.stackData = stack;
+        updateStack(stack);
         addRenderLayer(new ThighHighsDecorationArmorLayer(this, stack));
         addRenderLayer(new ThighHighsDecorationDetailArmorLayer(this, stack));
     }
 
     @Override
     public void prepForRender(@Nullable Entity entity, ItemStack stack, @Nullable EquipmentSlot slot, @Nullable HumanoidModel<?> baseModel) {
-        this.stackData = stack;
+        updateStack(stack);
         ((ThighHighsDecorationArmorLayer)getRenderLayers().get(0)).updateStack(stack);
         ((ThighHighsDecorationDetailArmorLayer)getRenderLayers().get(1)).updateStack(stack);
         super.prepForRender(entity, stack, slot, baseModel);
@@ -33,6 +43,6 @@ public class ThighHighsArmorRender extends GeoArmorItemRenderer<ThighHighsArmorI
 
     @Override
     public Color getRenderColor(ThighHighsArmorItem animatable, float partialTick, int packedLight) {
-        return Color.ofOpaque(stackData.get(DataComponentRegister.DYEABLE.get()).getBase());
+        return Color.ofOpaque(getStack().get(DataComponentRegister.DYEABLE.get()).getBase());
     }
 }


### PR DESCRIPTION
Evidently GeckoLib means something else for postRender.

This time, actually tested to some degree.