### PR TITLE
Fix: reduce PacifyEntityMixin overhead

### DIFF
--- a/src/main/java/com/hakimen/kawaiidishes/mixin/PacifyEntityMixin.java
+++ b/src/main/java/com/hakimen/kawaiidishes/mixin/PacifyEntityMixin.java
@@ -1,6 +1,7 @@
 package com.hakimen.kawaiidishes.mixin;
 
 import com.hakimen.kawaiidishes.registry.EffectRegister;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -8,12 +9,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LivingEntity.class)
-public class PacifyEntityMixin {
+public abstract class PacifyEntityMixin {
 
-
-    @Inject(at = @At("RETURN"), method = "canTarget(Lnet/minecraft/entity/LivingEntity;)Z", cancellable = true)
-    public void canAttack(LivingEntity entity, CallbackInfoReturnable<Boolean> cir){
-        cir.setReturnValue(!((LivingEntity)(Object) this).hasStatusEffect(EffectRegister.CALMING.get()) && cir.getReturnValue());
+    @ModifyReturnValue(method = "canTarget(Lnet/minecraft/entity/LivingEntity;)Z", at = @At("RETURN"))
+    private boolean kawaiidishes$pacify(boolean canTarget, LivingEntity target) {
+        return canTarget && !((LivingEntity) (Object) this).hasStatusEffect(EffectRegister.CALMING.get());
     }
-
 }


### PR DESCRIPTION
## Fix: reduce PacifyEntityMixin overhead

Before

```java
@Inject(at = @At("RETURN"),
        method = "canTarget(Lnet/minecraft/entity/LivingEntity;)Z",
        cancellable = true)
public void canAttack(LivingEntity target, CallbackInfoReturnable<Boolean> cir) {
    cir.setReturnValue(!((LivingEntity)(Object)this)
            .hasStatusEffect(EffectRegister.CALMING.get()) && cir.getReturnValue());
}
```

After

```java
@ModifyReturnValue(
    method = "canTarget(Lnet/minecraft/entity/LivingEntity;)Z",
    at = @At("RETURN"))
private boolean calm(boolean canTarget) {
    return canTarget && !((LivingEntity)(Object)this)
            .hasStatusEffect(EffectRegister.CALMING.get());
}
```

The old `@Inject` path creates a `CallbackInfoReturnable` object and stops the JVM from inlining `canTarget()`.  The new `@ModifyReturnValue` touches only the return bit—no allocation, inlining kept.

#### Impact (Spark, 30 s capture — 5 players, \~7 900 chunks, \~1 000 entities)

| build   | server‑thread share | total time |
| ------- | ------------------- | ---------- |
| v1.11.1 | 55.63 %                | 1.59 s     |
| this PR | 0.16 %              | 0.000 21 s |

In the same server TPS improves from \~8.5 → 20.

<img width="1540" height="376" alt="image" src="https://github.com/user-attachments/assets/9e62f15a-5cdb-4489-aa0d-c93fca8eab8e" />
<img width="404" height="230" alt="image" src="https://github.com/user-attachments/assets/e190bc2a-ca32-47d2-9f74-02f84d40bd83" />


<img width="1500" height="370" alt="image" src="https://github.com/user-attachments/assets/664b9584-6b81-4500-aaf7-92ad123e4c14" />
<img width="462" height="123" alt="image" src="https://github.com/user-attachments/assets/81542414-de5f-4f31-93fb-9a8e98d79888" />
